### PR TITLE
Add automatic VPNBook password retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@ Elle propose :
 - L’affichage de la latence en temps réel
 - La sauvegarde des logs dans un fichier texte
 - L’option pour afficher/masquer le mot de passe
+- La récupération automatique du mot de passe depuis le site VPNBook
 
 ⚠️ **Attention :**
 - Ce projet utilise les identifiants **VPNBook** (gratuits et publics).
 - Le mot de passe est enregistré en local dans un fichier `mdp.json`
+
+## 📦 Dépendances
+
+L'application nécessite quelques bibliothèques supplémentaires :
+
+- `requests`
+- `Pillow`
+- `pytesseract`
+- `beautifulsoup4`
+
+Elles peuvent être installées via :
+
+```bash
+pip install requests pillow pytesseract beautifulsoup4
+```


### PR DESCRIPTION
## Summary
- auto-fetch VPNBook password via OCR and update saved credentials
- document dependencies for password retrieval

## Testing
- `python -m py_compile vpnbookgui.py`
- `pip install requests pillow pytesseract beautifulsoup4` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbcc895b483298587e69af094a2c7