### PR TITLE
Afficher l'image du mot de passe sans OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Elle propose :
 - L’affichage de la latence en temps réel
 - La sauvegarde des logs dans un fichier texte
 - L’option pour afficher/masquer le mot de passe
-- La récupération automatique du mot de passe depuis le site VPNBook
+- L’affichage automatique de l’image du mot de passe depuis le site VPNBook
 
 ⚠️ **Attention :**
 - Ce projet utilise les identifiants **VPNBook** (gratuits et publics).
@@ -24,29 +24,11 @@ L'application nécessite quelques bibliothèques supplémentaires :
 
 - `requests`
 - `Pillow`
-- `pytesseract`
 - `beautifulsoup4`
-
-codex/implement-vpn-password-fetching-function-dr8n0s
 Vous pouvez installer ces bibliothèques avec la commande suivante (veillez à
 utiliser le même interpréteur Python que celui utilisé pour lancer
 l'application) :
 
 ```bash
-python -m pip install requests pillow pytesseract beautifulsoup4
+python -m pip install requests pillow beautifulsoup4
 ```
-
-> `pytesseract` est seulement une interface Python : le moteur
-> [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) doit aussi être
-> installé sur votre système.
-> - **Windows** : téléchargez l'installateur depuis
->   [UB Mannheim](https://github.com/UB-Mannheim/tesseract/wiki) et assurez-vous
->   que `tesseract.exe` est accessible dans votre `PATH`.
-> - **Linux** : `sudo apt install tesseract-ocr`.
-=======
-Elles peuvent être installées via :
-
-```bash
-pip install requests pillow pytesseract beautifulsoup4
-```
- main


### PR DESCRIPTION
## Summary
- remplace l'OCR par un téléchargement direct de l'image du mot de passe
- affiche cette image dans l'interface et supprime l'insertion automatique du mot de passe
- met à jour la documentation en supprimant la dépendance `pytesseract`

## Testing
- `python -m py_compile vpnbookgui.py`


